### PR TITLE
use env variable for django secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Python 3x, pip, Django, Postgresql
 1. Install Python 3.x and Pip. Use virtual environment if your host has older python version and it cant be upgraded.
 2. Install PostgreSQL or some other Django-friendly database engine. Also you might want to install PgAdmin or any other administrative tool for your database.
 3. Go to your charts storage folder and run `pip install -r requirements.txt`. Unix users : you have to have python-dev package to install `psycopg2`.
-4. Create an empty database in Postgres (using either command line or `pgadmin`). Go to `charting_library_charts` folder and set up your database connection in `settings.py` (see `DATABASES` @ line #12).
+4. Create an empty database in Postgres (using either command line or `pgadmin`). Go to `charting_library_charts` folder and set up your database connection in `settings.py` (see `DATABASES` @ line #16).
 5. Run `python manage.py migrate`. This will create database schema without any data.
 6. Generate a secret key by running `python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'`
 7. Set your secret key to your environment variables `export SECRET_KEY='...'`

--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ Python 3x, pip, Django, Postgresql
 3. Go to your charts storage folder and run `pip install -r requirements.txt`. Unix users : you have to have python-dev package to install `psycopg2`.
 4. Create an empty database in Postgres (using either command line or `pgadmin`). Go to `charting_library_charts` folder and set up your database connection in `settings.py` (see `DATABASES` @ line #12).
 5. Run `python manage.py migrate`. This will create database schema without any data.
-6. Run `python manage.py runserver` to run *TEST* instance of your database. Use some other stuff (i.e., Gunicorn) for your production environment.
-
+6. Generate a secret key by running `python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'`
+7. Set your secret key to your environment variables `export SECRET_KEY='...'`
+8. Run `python manage.py runserver` to run *TEST* instance of your database. Use some other stuff (i.e., Gunicorn) for your production environment.

--- a/charting_library_charts/settings.py
+++ b/charting_library_charts/settings.py
@@ -83,7 +83,7 @@ STATICFILES_FINDERS = (
 )
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = 'c5-%u0l1*(dj@u33!5*o_gtti0)kkh$m%i#@!(!$d%779kaa&amp;b'
+SECRET_KEY = os.getenv('SECRET_KEY', 'c5-%u0l1*(dj@u33!5*o_gtti0)kkh$m%i#@!(!$d%779kaa&amp;b')
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (


### PR DESCRIPTION
From this [post](https://stackoverflow.com/a/47117966):
> The cryptographic signing API in Django is available to any app for cryptographically-secure signatures on values. Django itself makes use of this in various higher-level features:
Signing serialised data (e.g. JSON documents).
Unique tokens for a user session, password reset request, messages, etc.
Prevention of cross-site or replay attacks by adding (and then expecting) unique values for the request.
Generating a unique salt for hash functions.

Changing it should not affect this application. 