### PR TITLE
Fix: Modernize for Python 3.12, Django 4.2+, and PostgreSQL 15+ Compatibility

### DIFF
--- a/api/v10/urls.py
+++ b/api/v10/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path as url
 from . import views
 from django.views.decorators.csrf import csrf_exempt
 

--- a/charting_library_charts/settings.py
+++ b/charting_library_charts/settings.py
@@ -21,6 +21,9 @@ DATABASES = {
 		'PASSWORD': os.getenv('DB_PASSWORD', 'postgres'),
 		'HOST': os.getenv('DB_HOST', 'localhost'),
 		'PORT': int(os.getenv('DB_PORT', '5432')),
+		'OPTIONS': {
+            'options': '-c timezone=UTC',
+        },
 	}
 }
 

--- a/charting_library_charts/urls.py
+++ b/charting_library_charts/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path as url
 
 urlpatterns = [
     url(r'^1\.0/', include('api.v10.urls')),

--- a/model/models.py
+++ b/model/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django_prometheus.models import ExportModelOperationsMixin
-from jsonfield import JSONField
+from django.db.models import JSONField
 
 
 class Chart(ExportModelOperationsMixin('charts'), models.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.2.28
-psycopg2<2.9
-jsonfield==2.1.1
-django-prometheus==2.2.0
+Django>=4.2.0,<5.0.0
+psycopg2-binary>=2.9.0
+django-prometheus>=2.2.0
+setuptools>=65.0.0


### PR DESCRIPTION
## Overview
This PR updates the backend to support modern deployment environments (Python 3.12, Django 4.2+, and PostgreSQL 15+). The current `master` branch relies on Django 2.2 and outdated dependencies that completely fail to build or run on newer Ubuntu/Linux distributions.

## Key Issues Resolved

**1. Python 3.12 `distutils` Missing Error**
* **Issue:** Python 3.12 removed the standard `distutils` library, causing the initial `manage.py` commands to crash.
* **Fix:** Added `setuptools` to `requirements.txt` to restore compatibility.

**2. Gunicorn 502 Bad Gateway (`jsonfield` deprecation)**
* **Issue:** The external `jsonfield` package tries to import `ugettext_lazy` and `force_text`, both of which were removed in Django 4.0+. This causes Gunicorn workers to silently fail on boot.
* **Fix:** Removed the `jsonfield` dependency entirely and swapped `model/models.py` to use Django's native `django.db.models.JSONField`.

**3. PostgreSQL 16 Timezone `AssertionError`**
* **Issue:** Modern PostgreSQL drivers strictly enforce timezone awareness. Retrieving a saved chart throws `AssertionError: database connection isn't set to UTC`.
* **Fix:** Added `'OPTIONS': {'options': '-c timezone=UTC'}` to the `DATABASES` configuration in `settings.py` to force the connection to UTC.

**4. Django 4.0 URL Routing Crash**
* **Issue:** `django.conf.urls.url` was removed in Django 4.0, causing 500 errors on API endpoints.
* **Fix:** Updated all `urls.py` imports to use the modern equivalent: `from django.urls import re_path as url`.

**5. Database Driver Build Failures**
* **Issue:** `psycopg2` fails to compile on modern Linux kernels without local C-compilers.
* **Fix:** Swapped `requirements.txt` to use `psycopg2-binary` for pre-compiled wheel support.

## Testing
Successfully tested saving, loading, and listing charts on an Ubuntu 24.04 LTS instance running Python 3.12 and PostgreSQL 16 via Gunicorn and Nginx.